### PR TITLE
Format readme example with prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,64 +26,66 @@ Usage:
 
 ```jsx
 // Import React FilePond
-import { FilePond, registerPlugin } from 'react-filepond';
+import { FilePond, registerPlugin } from "react-filepond";
 
 // Import FilePond styles
-import 'filepond/dist/filepond.min.css';
+import "filepond/dist/filepond.min.css";
 
 // Import the Image EXIF Orientation and Image Preview plugins
 // Note: These need to be installed separately
-import FilePondPluginImageExifOrientation from 'filepond-plugin-image-exif-orientation';
-import FilePondPluginImagePreview from 'filepond-plugin-image-preview';
-import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css';
+import FilePondPluginImageExifOrientation from "filepond-plugin-image-exif-orientation";
+import FilePondPluginImagePreview from "filepond-plugin-image-preview";
+import "filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css";
 
 // Register the plugins
 registerPlugin(FilePondPluginImageExifOrientation, FilePondPluginImagePreview);
 
 // Our app
 class App extends Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            // Set initial files, type 'local' means this is a file
-            // that has already been uploaded to the server (see docs)
-            files: [{
-                source: 'index.html',
-                options: {
-                    type: 'local'
-                }
-            }]
-        };
-    }
+    this.state = {
+      // Set initial files, type 'local' means this is a file
+      // that has already been uploaded to the server (see docs)
+      files: [
+        {
+          source: "index.html",
+          options: {
+            type: "local"
+          }
+        }
+      ]
+    };
+  }
 
-    handleInit() {
-        console.log('FilePond instance has initialised', this.pond);
-    }
+  handleInit() {
+    console.log("FilePond instance has initialised", this.pond);
+  }
 
-    render() {
-        return (
-            <div className="App">
-            
-                {/* Pass FilePond properties as attributes */}
-                <FilePond ref={ref => this.pond = ref}
-                          files={this.state.files}
-                          allowMultiple={true}
-                          maxFiles={3} 
-                          server="/api"
-                          oninit={() => this.handleInit() }
-                          onupdatefiles={fileItems => {
-                              // Set currently active file objects to this.state
-                              this.setState({
-                                  files: fileItems.map(fileItem => fileItem.file)
-                              });
-                          }}>
-                </FilePond>
-                
-            </div>
-        );
-    }
+  render() {
+    return (
+      <div className="App">
+        {/* Pass FilePond properties as attributes */}
+        <FilePond
+          ref={ref => (this.pond = ref)}
+          files={this.state.files}
+          allowMultiple={true}
+          maxFiles={3}
+          server="/api"
+          oninit={() => this.handleInit()}
+          onupdatefiles={fileItems => {
+            // Set currently active file objects to this.state
+            this.setState({
+              files: fileItems.map(fileItem => fileItem.file)
+            });
+          }}
+        />
+      </div>
+    );
+  }
 }
+
 ```
 
 [Read the docs for more information](https://pqina.nl/filepond/docs/patterns/frameworks/react/)


### PR DESCRIPTION
Hi!

I saw you had put some effort into making a good looking readme.

What are your thoughts on prettier? I thought that as you need to maintain these libraries for multiple other libraries and frameworks, it can be a bit difficult to keep up with syntax choices in each. Prettier kind of let's you work around that. Using standard format might make the readme look that one bit more polished. I guess whether it looks better or not is up to everyone's personal judgment, but at least it does look more uniform with other react/JS libraries :)

I've attached an example in this PR.