### PR TITLE
Add name example to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ class App extends Component {
           allowMultiple={true}
           maxFiles={3}
           server="/api"
+          name="files" {* sets the file input name, it's filepond by default *}
           oninit={() => this.handleInit()}
           onupdatefiles={fileItems => {
             // Set currently active file objects to this.state


### PR DESCRIPTION
Add a name parameter example in the README .

Sometimes we have no control on the backend and setting the form field name need to be changed in the frontend. I can't find anything on the docs, only in a issue at FilePond repository, quoting that it takes it from the input, but since in this case react-filepond is creating the input this option get shadowed.

I have to resort to code to find this out, inexperienced users may resist to this and give up, or get frustrated.