### PR TITLE
Remove extraneous { } from README code

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ function App() {
         allowMultiple={true}
         maxFiles={3}
         server="/api"
-        name="files" {/* sets the file input name, it's filepond by default */}
+        name="files" /* sets the file input name, it's filepond by default */
         labelIdle='Drag & Drop your files or <span class="filepond--label-action">Browse</span>'
       />
     </div>

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ class App extends Component {
           allowReorder={true}
           maxFiles={3}
           server="/api"
-          name="files" {/* sets the file input name, it's filepond by default */}
+          name="files" /* sets the file input name, it's filepond by default */
           oninit={() => this.handleInit()}
           onupdatefiles={fileItems => {
             // Set currently active file objects to this.state


### PR DESCRIPTION
The example code throws an "expected ..." error when the curly brackets on this line are included.